### PR TITLE
Duplicate lesson navigation to top and bottom

### DIFF
--- a/lesson.html
+++ b/lesson.html
@@ -66,6 +66,21 @@
             <div class="lesson-content" id="lessonContent">
                 <!-- Le contenu sera chargé dynamiquement -->
             </div>
+
+            <!-- Navigation de leçon (en bas) -->
+            <div class="lesson-nav">
+                <button class="nav-button prev" id="prevButtonBottom" onclick="previousLesson()">
+                    ← Précédent
+                </button>
+                
+                <button class="complete-button" id="completeButtonBottom" onclick="markAsCompleted()">
+                    Marquer comme terminé
+                </button>
+                
+                <button class="nav-button next" id="nextButtonBottom" onclick="nextLesson()">
+                    Suivant →
+                </button>
+            </div>
         </div>
     </div>
 
@@ -183,11 +198,16 @@
             updateProgress();
             generateNavigation();
             
-            // Changer le bouton
+            // Changer les boutons
             const completeButton = document.getElementById('completeButton');
+            const completeButtonBottom = document.getElementById('completeButtonBottom');
             completeButton.textContent = '✓ Terminé';
             completeButton.style.background = '#28a745';
             completeButton.disabled = true;
+            
+            completeButtonBottom.textContent = '✓ Terminé';
+            completeButtonBottom.style.background = '#28a745';
+            completeButtonBottom.disabled = true;
             
             // Notification
             showNotification('Leçon marquée comme terminée !');
@@ -220,20 +240,33 @@
             const nextButton = document.getElementById('nextButton');
             const completeButton = document.getElementById('completeButton');
             
+            // Boutons du bas
+            const prevButtonBottom = document.getElementById('prevButtonBottom');
+            const nextButtonBottom = document.getElementById('nextButtonBottom');
+            const completeButtonBottom = document.getElementById('completeButtonBottom');
+            
             // Vérifier si la leçon est déjà terminée
             const lessonKey = `module_${currentModule}_lesson_${currentLesson}`;
             const progress = JSON.parse(localStorage.getItem('lessonProgress') || '{}');
             const isCompleted = progress[lessonKey] && progress[lessonKey].completed;
             
-            // Réinitialiser le bouton
+            // Réinitialiser les boutons de complétion
             completeButton.textContent = 'Marquer comme terminé';
             completeButton.style.background = '#007bff';
             completeButton.disabled = false;
+            
+            completeButtonBottom.textContent = 'Marquer comme terminé';
+            completeButtonBottom.style.background = '#007bff';
+            completeButtonBottom.disabled = false;
             
             if (isCompleted) {
                 completeButton.textContent = '✓ Terminé';
                 completeButton.style.background = '#28a745';
                 completeButton.disabled = true;
+                
+                completeButtonBottom.textContent = '✓ Terminé';
+                completeButtonBottom.style.background = '#28a745';
+                completeButtonBottom.disabled = true;
             }
             
             // Gérer les boutons de navigation
@@ -243,17 +276,25 @@
             if (!prevLesson) {
                 prevButton.disabled = true;
                 prevButton.style.display = 'none';
+                prevButtonBottom.disabled = true;
+                prevButtonBottom.style.display = 'none';
             } else {
                 prevButton.disabled = false;
                 prevButton.style.display = 'block';
+                prevButtonBottom.disabled = false;
+                prevButtonBottom.style.display = 'block';
             }
             
             if (!nextLesson) {
                 nextButton.disabled = true;
                 nextButton.style.display = 'none';
+                nextButtonBottom.disabled = true;
+                nextButtonBottom.style.display = 'none';
             } else {
                 nextButton.disabled = false;
                 nextButton.style.display = 'block';
+                nextButtonBottom.disabled = false;
+                nextButtonBottom.style.display = 'block';
             }
         }
         

--- a/pdf-downloads.html
+++ b/pdf-downloads.html
@@ -66,6 +66,21 @@
             <div class="lesson-content" id="pdfContent">
                 <!-- Le contenu sera chargé dynamiquement -->
             </div>
+
+            <!-- Navigation de leçon (en bas) -->
+            <div class="lesson-nav">
+                <button class="nav-button prev" id="prevButtonBottom" onclick="previousLesson()">
+                    ← Précédent
+                </button>
+                
+                <button class="complete-button" id="completeButtonBottom" onclick="markAsCompleted()">
+                    Marquer comme terminé
+                </button>
+                
+                <button class="nav-button next" id="nextButtonBottom" onclick="nextLesson()">
+                    Suivant →
+                </button>
+            </div>
         </div>
     </div>
 
@@ -123,11 +138,16 @@
             updateProgress();
             generateNavigation();
             
-            // Changer le bouton
+            // Changer les boutons
             const completeButton = document.getElementById('completeButton');
+            const completeButtonBottom = document.getElementById('completeButtonBottom');
             completeButton.textContent = '✓ Terminé';
             completeButton.style.background = '#28a745';
             completeButton.disabled = true;
+            
+            completeButtonBottom.textContent = '✓ Terminé';
+            completeButtonBottom.style.background = '#28a745';
+            completeButtonBottom.disabled = true;
             
             // Notification
             showNotification('Document marqué comme consulté !');
@@ -158,15 +178,33 @@
             const nextButton = document.getElementById('nextButton');
             const completeButton = document.getElementById('completeButton');
             
+            // Boutons du bas
+            const prevButtonBottom = document.getElementById('prevButtonBottom');
+            const nextButtonBottom = document.getElementById('nextButtonBottom');
+            const completeButtonBottom = document.getElementById('completeButtonBottom');
+            
             // Vérifier si la leçon est déjà terminée
             const lessonKey = `module_${currentModule}_lesson_${currentLesson}`;
             const progress = JSON.parse(localStorage.getItem('lessonProgress') || '{}');
             const isCompleted = progress[lessonKey] && progress[lessonKey].completed;
             
+            // Réinitialiser les boutons de complétion
+            completeButton.textContent = 'Marquer comme terminé';
+            completeButton.style.background = '#007bff';
+            completeButton.disabled = false;
+            
+            completeButtonBottom.textContent = 'Marquer comme terminé';
+            completeButtonBottom.style.background = '#007bff';
+            completeButtonBottom.disabled = false;
+            
             if (isCompleted) {
                 completeButton.textContent = '✓ Terminé';
                 completeButton.style.background = '#28a745';
                 completeButton.disabled = true;
+                
+                completeButtonBottom.textContent = '✓ Terminé';
+                completeButtonBottom.style.background = '#28a745';
+                completeButtonBottom.disabled = true;
             }
             
             // Gérer les boutons de navigation
@@ -175,10 +213,18 @@
             
             if (!prevLesson) {
                 prevButton.disabled = true;
+                prevButtonBottom.disabled = true;
+            } else {
+                prevButton.disabled = false;
+                prevButtonBottom.disabled = false;
             }
             
             if (!nextLesson) {
                 nextButton.disabled = true;
+                nextButtonBottom.disabled = true;
+            } else {
+                nextButton.disabled = false;
+                nextButtonBottom.disabled = false;
             }
         }
         

--- a/style.css
+++ b/style.css
@@ -297,6 +297,12 @@ body {
     border-radius: 8px;
 }
 
+/* Navigation de leçon en bas */
+.lesson-nav:last-of-type {
+    margin-top: 30px;
+    margin-bottom: 0;
+}
+
 .nav-button {
     padding: 10px 20px;
     border: none;


### PR DESCRIPTION
Duplicate lesson navigation to the bottom of lesson and PDF pages to improve accessibility.

The navigation buttons (previous, complete, next) are now present at both the top and bottom of `lesson.html` and `pdf-downloads.html`, with synchronized functionality and appropriate CSS spacing.

---
<a href="https://cursor.com/background-agent?bcId=bc-c7daffd2-507f-4616-b9e0-320d90b79909"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c7daffd2-507f-4616-b9e0-320d90b79909"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

