### PR TITLE
Remove duplicate lesson titles

### DIFF
--- a/lesson-content-module1.js
+++ b/lesson-content-module1.js
@@ -5,8 +5,6 @@ window.module1Content = {
         moduleTitle: "Module 1 : Mettre ses compétences au service de son projet",
         type: "video",
         content: `
-            <h1>🎯 À quoi vous attendre dans ce premier module</h1>
-            
             <p>Bienvenue dans ce premier module de formation ! Vous allez découvrir les fondations essentielles de l'entrepreneuriat.</p>
             
             <div style="text-align: center; margin: 30px 0;">
@@ -40,8 +38,6 @@ window.module1Content = {
         title: "Comment lancer son projet d'entreprise sans se louper",
         moduleTitle: "Module 1 : Mettre ses compétences au service de son projet",
         content: `
-            <h1>🚀 Comment lancer son projet d'entreprise sans se louper</h1>
-            
             <p>Lancer un projet d'entreprise est une aventure passionnante mais qui nécessite une approche méthodique pour éviter les pièges courants.</p>
             
             <div style="text-align: center; margin: 30px 0;">
@@ -89,8 +85,6 @@ window.module1Content = {
         title: "Présentation des compétences requises pour être un chef d'entreprise",
         moduleTitle: "Module 1 : Mettre ses compétences au service de son projet",
         content: `
-            <h1>🤔 Démarrez avec un fait intrigant !</h1>
-            
             <p>Saviez-vous que plus de 90 % des startups échouent dans leurs premières années d'existence ? Ce chiffre montre qu'être un chef d'entreprise demande bien plus que d'avoir une bonne idée : il faut des compétences diverses et bien développées.</p>
             
             <h2>🛠️ Compétences Requises pour l'Entrepreneuriat</h2>
@@ -191,8 +185,6 @@ window.module1Content = {
         title: "Comprendre l'importance des compétences entrepreneuriales",
         moduleTitle: "Module 1 : Mettre ses compétences au service de son projet",
         content: `
-            <h1>🎯 Comprendre l'importance des compétences entrepreneuriales</h1>
-            
             <p>Les compétences entrepreneuriales sont le fondement du succès en entreprise. Elles déterminent votre capacité à transformer une idée en réalité et à naviguer dans l'environnement complexe des affaires.</p>
             
             <h2>🔍 Pourquoi ces compétences sont-elles cruciales ?</h2>
@@ -242,8 +234,6 @@ window.module1Content = {
         title: "Analyse des compétences clés pour gérer une entreprise",
         moduleTitle: "Module 1 : Mettre ses compétences au service de son projet",
         content: `
-            <h1>🔍 Analyse des compétences clés pour gérer une entreprise</h1>
-            
             <p>Saviez-vous que plus de 60% des nouvelles entreprises échouent dans les trois premières années ? Ce chiffre alarmant met en évidence l'importance cruciale des compétences clés pour une gestion efficace d'une entreprise. Explorons ces compétences essentielles et voyons comment elles peuvent transformer une entreprise naissante en une success story durable.</p>
             
             <h2>💸 Littératie financière</h2>
@@ -319,8 +309,6 @@ Décrivez comment la gestion des ressources humaines peut contribuer à la crois
         title: "Synthèse",
         moduleTitle: "Module 1 : Mettre ses compétences au service de son projet",
         content: `
-            <h1>📋 Synthèse du Module 1</h1>
-        
             <p>Félicitations ! Vous avez terminé le premier module de votre formation en entrepreneuriat. Récapitulons les points clés que nous avons abordés.</p>
         
         <div style="text-align: center; margin: 30px 0;">
@@ -412,8 +400,6 @@ Décrivez comment la gestion des ressources humaines peut contribuer à la crois
         title: "SMART Goals",
         moduleTitle: "Module 1 : Mettre ses compétences au service de son projet",
         content: `
-            <h1>🎯 SMART Goals</h1>
-            
             <p>Les objectifs SMART sont un outil puissant pour définir et atteindre vos objectifs entrepreneuriaux de manière efficace et mesurable.</p>
             
             <div style="text-align: center; margin: 30px 0;">
@@ -502,8 +488,6 @@ Décrivez comment la gestion des ressources humaines peut contribuer à la crois
         moduleTitle: "Module 1 : Mettre ses compétences au service de son projet",
         type: "pdf",
         content: `
-            <h1>📄 Fiches Complémentaires - Module 1</h1>
-            
             <p>Voici les documents complémentaires pour approfondir les concepts abordés dans ce module.</p>
             
             <div class="pdf-grid">

--- a/lesson-content-module10.js
+++ b/lesson-content-module10.js
@@ -4,8 +4,6 @@ window.module10Content = {
         title: "Identifier votre marché cible",
         moduleTitle: "Module 10 : Trouver ses clients en étudiant son marché",
         content: `
-        <h1>📚 Identifier votre marché cible</h1>
-        
         <p>Cette leçon fait partie du Module 10 : Trouver ses clients en étudiant son marché. Vous allez découvrir comment identifier et analyser votre marché cible pour développer votre activité.</p>
         
         <div style="text-align: center; margin: 30px 0;">
@@ -128,7 +126,6 @@ window.module10Content = {
         title: "Étude approfondie du marché cible",
         moduleTitle: "Module 10 : Trouver ses clients en étudiant son marché",
         content: `
-        <h1>📚 Étude approfondie du marché cible</h1>
         
         <p>Cette leçon fait partie du Module 10 : Trouver ses clients en étudiant son marché. Vous allez approfondir votre compréhension du marché cible avec des méthodes d'analyse plus avancées.</p>
         
@@ -240,7 +237,6 @@ window.module10Content = {
         title: "Stratégies pour se démarquer des concurrents",
         moduleTitle: "Module 10 : Trouver ses clients en étudiant son marché",
         content: `
-        <h1>📚 Stratégies pour se démarquer des concurrents</h1>
         
         <p>Cette leçon fait partie du Module 10 : Trouver ses clients en étudiant son marché. Vous allez découvrir comment développer des stratégies efficaces pour vous différencier de la concurrence.</p>
         
@@ -355,7 +351,6 @@ window.module10Content = {
         title: "Création d'une identité commerciale distinctive",
         moduleTitle: "Module 10 : Trouver ses clients en étudiant son marché",
         content: `
-        <h1>📚 Création d'une identité commerciale distinctive</h1>
         
         <p>Cette leçon fait partie du Module 10 : Trouver ses clients en étudiant son marché. Vous allez découvrir comment créer une identité commerciale forte et distinctive pour votre entreprise.</p>
         
@@ -455,7 +450,6 @@ window.module10Content = {
         title: "Comprendre les attentes clients avec le Value Proposition Canvas",
         moduleTitle: "Module 10 : Trouver ses clients en étudiant son marché",
         content: `
-        <h1>📚 Comprendre les attentes clients avec le Value Proposition Canvas</h1>
         
         <p>Cette leçon fait partie du Module 10 : Trouver ses clients en étudiant son marché. Vous allez découvrir comment utiliser le Value Proposition Canvas pour comprendre et répondre aux attentes de vos clients.</p>
         

--- a/lesson-content-module11.js
+++ b/lesson-content-module11.js
@@ -4,8 +4,6 @@ window.module11Content = {
         title: "Comprendre la Valeur de son Offre",
         moduleTitle: "Module 11 : Valoriser son offre et choisir son circuit de distribution",
         content: `
-        <h1>📚 Comprendre la Valeur de son Offre</h1>
-        
         <p>Cette leçon fait partie du Module 11 : Valoriser son offre et choisir son circuit de distribution. Vous allez découvrir comment comprendre et valoriser efficacement votre offre commerciale.</p>
         
         <div style="text-align: center; margin: 30px 0;">
@@ -132,7 +130,6 @@ window.module11Content = {
         title: "Prospection et valorisation de l'offre commerciale",
         moduleTitle: "Module 11 : Valoriser son offre et choisir son circuit de distribution",
         content: `
-        <h1>📚 Prospection et valorisation de l'offre commerciale</h1>
         
         <p>Cette leçon fait partie du Module 11 : Valoriser son offre et choisir son circuit de distribution. Vous allez découvrir les techniques de prospection et de valorisation commerciale.</p>
         
@@ -232,7 +229,6 @@ window.module11Content = {
         title: "Création d'outils de communication adaptés à l'entreprise",
         moduleTitle: "Module 11 : Valoriser son offre et choisir son circuit de distribution",
         content: `
-        <h1>📚 Création d'outils de communication adaptés à l'entreprise</h1>
         
         <p>Cette leçon fait partie du Module 11 : Valoriser son offre et choisir son circuit de distribution. Vous allez découvrir comment créer des outils de communication efficaces pour votre entreprise.</p>
         
@@ -361,7 +357,6 @@ window.module11Content = {
         title: "Détermination du juste prix et du coût de revient",
         moduleTitle: "Module 11 : Valoriser son offre et choisir son circuit de distribution",
         content: `
-        <h1>📚 Détermination du juste prix et du coût de revient</h1>
         
         <p>Cette leçon fait partie du Module 11 : Valoriser son offre et choisir son circuit de distribution. Vous allez découvrir comment déterminer le juste prix et calculer le coût de revient.</p>
         

--- a/lesson-content-module12.js
+++ b/lesson-content-module12.js
@@ -4,8 +4,6 @@ window.module12Content = {
         title: "Comprendre ses Clients",
         moduleTitle: "Module 12 : Cibler les actions commerciales adaptées à ses clients",
         content: `
-        <h1>📚 Comprendre ses Clients</h1>
-        
         <p>Cette leçon fait partie du Module 12 : Cibler les actions commerciales adaptées à ses clients. Vous allez découvrir comment comprendre vos clients pour adapter vos actions commerciales.</p>
         
         <div style="text-align: center; margin: 30px 0;">
@@ -123,7 +121,6 @@ window.module12Content = {
         title: "Identification des meilleures actions commerciales adaptées",
         moduleTitle: "Module 12 : Cibler les actions commerciales adaptées à ses clients",
         content: `
-        <h1>📚 Identification des meilleures actions commerciales adaptées</h1>
         
         <p>Cette leçon fait partie du Module 12 : Cibler les actions commerciales adaptées à ses clients. Vous allez découvrir comment identifier et mettre en place les meilleures actions commerciales adaptées à vos clients.</p>
         
@@ -257,7 +254,6 @@ window.module12Content = {
         title: "Création de stratégies pour fidéliser la clientèle",
         moduleTitle: "Module 12 : Cibler les actions commerciales adaptées à ses clients",
         content: `
-        <h1>📚 Création de stratégies pour fidéliser la clientèle</h1>
         
         <p>Cette leçon fait partie du Module 12 : Cibler les actions commerciales adaptées à ses clients. Vous allez découvrir comment créer des stratégies efficaces pour fidéliser vos clients et développer leur valeur à long terme.</p>
         
@@ -397,7 +393,6 @@ window.module12Content = {
         title: "Élaboration d'un plan d'actions commerciales personnalisées",
         moduleTitle: "Module 12 : Cibler les actions commerciales adaptées à ses clients",
         content: `
-        <h1>📚 Élaboration d'un plan d'actions commerciales personnalisées</h1>
         
         <p>Cette leçon fait partie du Module 12 : Cibler les actions commerciales adaptées à ses clients. Vous allez découvrir comment élaborer un plan d'actions commerciales personnalisées, structuré et efficace.</p>
         
@@ -539,7 +534,6 @@ window.module12Content = {
         title: "Avant de vous lancer : erreurs classiques à éviter",
         moduleTitle: "Module 12 : Cibler les actions commerciales adaptées à ses clients",
         content: `
-        <h1>📚 Avant de vous lancer : erreurs classiques à éviter</h1>
         
         <p>Cette leçon fait partie du Module 12 : Cibler les actions commerciales adaptées à ses clients. Vous allez découvrir les erreurs classiques à éviter avant de vous lancer dans vos actions commerciales.</p>
         

--- a/lesson-content-module13.js
+++ b/lesson-content-module13.js
@@ -4,8 +4,6 @@ window.module13Content = {
         title: "Études de Cas",
         moduleTitle: "Module 13 : Études de cas",
         content: `
-        <h1>📚 Études de Cas</h1>
-        
         <p>Cette leçon fait partie du Module 13 : Études de cas. Vous allez découvrir des études de cas pratiques pour consolider vos acquis et voir l'application concrète des concepts abordés.</p>
         
         <div style="text-align: center; margin: 30px 0;">

--- a/lesson-content-module2.js
+++ b/lesson-content-module2.js
@@ -4,8 +4,6 @@ window.module2Content = {
         title: "Intro - Connaître son marché pour mieux vendre",
         moduleTitle: "Module 2 : Connaître son marché pour mieux vendre",
         content: `
-            <h1>📊 Intro - Connaître son marché pour mieux vendre</h1>
-        
             <p>L'analyse de marché est une étape fondamentale pour comprendre votre environnement concurrentiel et identifier les opportunités. Savoir qui sont vos clients, ce qu'ils veulent et comment vos concurrents répondent à leurs besoins est essentiel pour développer une stratégie commerciale efficace.</p>
         
         <div style="text-align: center; margin: 30px 0;">
@@ -128,8 +126,6 @@ window.module2Content = {
         title: "Analyse de la clientèle et de la concurrence",
         moduleTitle: "Module 2 : Connaître son marché pour mieux vendre",
         content: `
-            <h1>📊 Analyse de la clientèle et de la concurrence</h1>
-            
             <p>Comprendre vos clients et vos concurrents est essentiel pour développer une stratégie commerciale efficace. Une analyse approfondie de la clientèle et de la concurrence permet de formuler des stratégies efficaces pour capter et fidéliser la clientèle.</p>
             
             <h2>📊 Analyse de la clientèle : Un aperçu démographique et comportemental</h2>
@@ -199,8 +195,6 @@ window.module2Content = {
         title: "Mise en place de stratégies basées sur la connaissance du marché",
         moduleTitle: "Module 2 : Connaître son marché pour mieux vendre",
         content: `
-            <h1>🎯 Mise en place de stratégies basées sur la connaissance du marché</h1>
-            
             <h2>💡 Quel est le secret des entreprises qui réussissent ?</h2>
             <p>Souvent, c'est leur capacité à comprendre parfaitement le marché et à développer des stratégies efficaces basées sur cette connaissance. Plongeons dans l'art de transformer les données du marché en actions concrètes qui mènent au succès.</p>
             
@@ -238,8 +232,6 @@ window.module2Content = {
         title: "Utilisation des documents commerciaux pour mieux vendre",
         moduleTitle: "Module 2 : Connaître son marché pour mieux vendre",
         content: `
-            <h1>📄 Utilisation des documents commerciaux pour mieux vendre</h1>
-            
             <h2>📄📊 Pourquoi les documents commerciaux sont essentiels ?</h2>
             <p>Saviez-vous qu'environ 80% des ventes majeures sont conclues grâce à une documentation commerciale bien rédigée ? Ce chiffre montre clairement l'importance d'utiliser correctement ces outils pour améliorer vos ventes. Que vous vendiez des biens ou des services, les documents commerciaux tels que les <strong>📝 propositions de vente</strong>, les <strong>📜 contrats</strong> et les <strong>🧾 factures</strong> jouent un rôle crucial dans la communication et la négociation avec vos clients. Regardons de plus près comment ces documents peuvent être utilisés pour maximiser vos chances de succès.</p>
             
@@ -298,8 +290,6 @@ window.module2Content = {
         title: "Customer Journey Mapping",
         moduleTitle: "Module 2 : Connaître son marché pour mieux vendre",
         content: `
-            <h1>🗺️ Customer Journey Mapping</h1>
-            
             <p>Le Customer Journey Mapping vous permet de comprendre et d'optimiser l'expérience client à chaque étape de son parcours.</p>
             
             <h2>🖼️ Visualisation du Customer Journey</h2>
@@ -442,8 +432,6 @@ window.module2Content = {
         moduleTitle: "Module 2 : Connaître son marché pour mieux vendre",
         type: "pdf",
         content: `
-            <h1>📄 Fiches Complémentaires - Module 2</h1>
-            
             <p>Voici les documents complémentaires pour approfondir l'analyse de marché et les stratégies commerciales.</p>
             
             <div class="pdf-grid">

--- a/lesson-content-module3.js
+++ b/lesson-content-module3.js
@@ -4,9 +4,7 @@ window.module3Content = {
         title: "Définir les besoins et la rentabilité du projet",
         moduleTitle: "Module 3 : Définir les besoins et la rentabilité du projet",
         content: `
-            <h1>💰 Définir les besoins et la rentabilité du projet</h1>
-        
-                        <p>Avant de lancer votre projet, il est essentiel d'identifier précisément vos besoins et d'évaluer sa rentabilité potentielle.</p>
+            <p>Avant de lancer votre projet, il est essentiel d'identifier précisément vos besoins et d'évaluer sa rentabilité potentielle.</p>
 
         
         <div style="text-align: center; margin: 30px 0;">
@@ -76,9 +74,7 @@ window.module3Content = {
         title: "Comprendre et structurer son projet avec le Business Model Canvas",
         moduleTitle: "Module 3 : Définir les besoins et la rentabilité du projet",
         content: `
-            <h1>🎨 Comprendre et structurer son projet avec le Business Model Canvas</h1>
-                    
-                <div style="text-align: center; margin: 30px 0;">
+            <div style="text-align: center; margin: 30px 0;">
                     <iframe width="560" height="315" src="https://www.youtube.com/embed/S9GAk_2de2g" frameborder="0" allowfullscreen style="max-width: 100%; border-radius: 8px;"></iframe>
                 </div>
             <p>Le Business Model Canvas est un outil visuel puissant pour structurer et présenter votre modèle économique de manière claire et synthétique.</p>
@@ -150,8 +146,6 @@ window.module3Content = {
         title: "Élaboration d'un compte de résultat",
         moduleTitle: "Module 3 : Définir les besoins et la rentabilité du projet",
         content: `
-            <h1>📊 Élaboration d'un compte de résultat</h1>
-            
             <p>🧐 Saviez-vous que chaque entreprise, peu importe sa taille, doit créer un <strong>💼 compte de résultat</strong> pour évaluer sa <strong>🔍 performance financière</strong>?</p>
             
             <p>Etablir un compte de résultat est indispensable pour tout entrepreneur désireux de comprendre la <strong>🏆 rentabilité</strong> de son entreprise. Cette déclaration vous permet d'avoir une vision claire de vos <strong>📈 revenus</strong>, <strong>📉 dépenses</strong> et <strong>🔁 profits</strong> ou <strong>❌ pertes</strong> sur une période donnée. Voici comment élaborer un compte de résultat de manière efficace :</p>
@@ -249,8 +243,6 @@ window.module3Content = {
         title: "Création d'un plan de financement",
         moduleTitle: "Module 3 : Définir les besoins et la rentabilité du projet",
         content: `
-            <h1>💳 Création d'un plan de financement</h1>
-            
             <p><strong>🌟 Un début intrigant : Saviez-vous que...</strong></p>
             
             <p>Saviez-vous que plus de 50% des startups échouent au cours de leurs cinq premières années, principalement en raison d'un manque de financement adéquat ? La création d'un <strong>🔑plan de financement</strong> est cruciale pour éviter ce piège et assurer la pérennité d'une entreprise. Voyons comment mettre en place un plan de financement efficace !</p>
@@ -354,8 +346,6 @@ window.module3Content = {
         title: "Présentation des outils de financement en partenariat avec un banquier",
         moduleTitle: "Module 3 : Définir les besoins et la rentabilité du projet",
         content: `
-            <h1>🏦 Présentation des outils de financement en partenariat avec un banquier</h1>
-            
             <p><strong>💡 Facteur Clé: Saviez-vous que 82% des entreprises qui échouent le font à cause de problèmes de trésorerie? Cela souligne l'importance cruciale de bien sélectionner les outils de financement pour un entrepreneur.</strong></p>
             
             <p><strong>Présentation des Outils de Financement en Partenariat avec un Banquier</strong></p>
@@ -453,8 +443,6 @@ window.module3Content = {
         title: "Plan Financier & Lean Canvas",
         moduleTitle: "Module 3 : Définir les besoins et la rentabilité du projet",
         content: `
-            <h1>📈 Plan Financier & Lean Canvas</h1>
-            
             <p>Le Lean Canvas est une version simplifiée du Business Model Canvas, spécialement conçue pour les startups et projets innovants.</p>
             
             <h2>🎨 Le Lean Canvas</h2>
@@ -563,8 +551,6 @@ window.module3Content = {
         moduleTitle: "Module 3 : Définir les besoins et la rentabilité du projet",
         type: "pdf",
         content: `
-            <h1>📄 Fiches Complémentaires - Module 3</h1>
-            
             <p>Voici les documents complémentaires pour approfondir la gestion financière et la structuration de votre projet.</p>
             
             <div class="pdf-grid">

--- a/lesson-content-module4.js
+++ b/lesson-content-module4.js
@@ -4,9 +4,7 @@ window.module4Content = {
         title: "Introduction aux structures juridiques",
         moduleTitle: "Module 4 : Choisir une structure juridique appropriée",
         content: `
-            <h1>⚖️ Introduction aux structures juridiques</h1>
-        
-                        <p>Le choix de la structure juridique est une décision fondamentale qui influencera tous les aspects de votre entreprise : fiscalité, responsabilité, gestion, et développement.</p>
+            <p>Le choix de la structure juridique est une décision fondamentale qui influencera tous les aspects de votre entreprise : fiscalité, responsabilité, gestion, et développement.</p>
 
         
         <div style="text-align: center; margin: 30px 0;">
@@ -95,8 +93,6 @@ window.module4Content = {
         title: "Présentation des différentes formes juridiques",
         moduleTitle: "Module 4 : Choisir une structure juridique appropriée",
         content: `
-            <h1>📋 Présentation des différentes formes juridiques</h1>
-            
             <div style="background: #e3f2fd; padding: 20px; border-radius: 8px; margin: 20px 0; border-left: 4px solid #2196f3;">
                 <h3>🌍🔍 Saviez-vous que... ?</h3>
                 <p>Une étude révèle que le choix de la forme juridique d'une entreprise peut avoir un impact significatif sur son succès à long terme, que ce soit en termes de responsabilités, de fiscalité ou de crédibilité. Découvrez comment les différentes formes juridiques peuvent transformer le destin d'une entreprise !</p>
@@ -168,8 +164,6 @@ window.module4Content = {
         title: "Comparaison des avantages et limites des structures juridiques",
         moduleTitle: "Module 4 : Choisir une structure juridique appropriée",
         content: `
-            <h1>⚖️ Comparaison des avantages et limites des structures juridiques</h1>
-            
             <div style="background: #e3f2fd; padding: 20px; border-radius: 8px; margin: 20px 0; border-left: 4px solid #2196f3;">
                 <h3>🤔 Introduction</h3>
                 <p>Avez-vous déjà réfléchi à la structure juridique qui convient le mieux à votre entreprise? Saviez-vous que le choix de la forme juridique peut avoir un impact significatif sur votre façon de gérer et de développer votre activité? Découvrons ensemble les avantages et limites de plusieurs structures juridiques pour mieux comprendre leurs implications sur vos opérations commerciales.</p>
@@ -294,8 +288,6 @@ window.module4Content = {
         title: "Sélection de la structure juridique adaptée au projet",
         moduleTitle: "Module 4 : Choisir une structure juridique appropriée",
         content: `
-            <h1>🎯 Sélection de la structure juridique adaptée au projet</h1>
-            
             <div style="background: #e3f2fd; padding: 20px; border-radius: 8px; margin: 20px 0; border-left: 4px solid #2196f3;">
                 <h3>📊 Analyse des Besoins de l'Entreprise</h3>
                 <p>Saviez-vous que la structure juridique de Google a commencé par une simple société de type LLC avant de devenir une entreprise publique cotée en bourse? Cette évolution démontre à quel point il est crucial de bien choisir sa structure juridique dès le début.</p>
@@ -374,8 +366,6 @@ window.module4Content = {
         moduleTitle: "Module 4 : Choisir une structure juridique appropriée",
         type: "pdf",
         content: `
-            <h1>📄 Fiches Complémentaires - Module 4</h1>
-            
             <p>Voici les documents complémentaires pour approfondir le choix de votre structure juridique.</p>
             
             <div class="pdf-grid">

--- a/lesson-content-module5.js
+++ b/lesson-content-module5.js
@@ -4,8 +4,6 @@ window.module5Content = {
         title: "Les régimes fiscaux des entreprises",
         moduleTitle: "Module 5 : Comprendre les différents régimes fiscaux",
         content: `
-        <h1>📚 Les régimes fiscaux des entreprises</h1>
-        
         <p>Cette leçon fait partie du Module 5 : Comprendre les différents régimes fiscaux. Vous allez découvrir les différents régimes fiscaux applicables aux entreprises et leurs spécificités.</p>
         
         <div style="text-align: center; margin: 30px 0;">
@@ -79,7 +77,6 @@ window.module5Content = {
         title: "Présentation des divers régimes fiscaux",
         moduleTitle: "Module 5 : Comprendre les différents régimes fiscaux",
         content: `
-        <h1>📚 Présentation des divers régimes fiscaux</h1>
         
         <p>Cette leçon détaille les différents régimes fiscaux applicables aux entreprises en France, leurs caractéristiques et leurs modalités d'application. Comprendre ces régimes est essentiel pour optimiser votre fiscalité et respecter vos obligations.</p>
         
@@ -262,7 +259,6 @@ window.module5Content = {
         title: "Comparaison des avantages et limites des régimes fiscaux",
         moduleTitle: "Module 5 : Comprendre les différents régimes fiscaux",
         content: `
-        <h1>📚 Comparaison des avantages et limites des régimes fiscaux</h1>
         
         <p>Cette leçon compare les avantages et limites de chaque régime fiscal pour vous aider à faire le meilleur choix selon votre situation. Une analyse comparative approfondie vous permettra d'optimiser votre fiscalité.</p>
         
@@ -507,7 +503,6 @@ window.module5Content = {
         title: "Sélection du régime fiscal approprié à l'entreprise",
         moduleTitle: "Module 5 : Comprendre les différents régimes fiscaux",
         content: `
-        <h1>📚 Sélection du régime fiscal approprié à l'entreprise</h1>
         
         <p>Cette leçon vous guide dans la sélection du régime fiscal le plus adapté à votre projet d'entreprise en fonction de vos caractéristiques spécifiques. Une méthode structurée vous permettra de prendre la meilleure décision.</p>
         

--- a/lesson-content-module6.js
+++ b/lesson-content-module6.js
@@ -4,8 +4,6 @@ window.module6Content = {
         title: "Introduction aux aides à la création d'entreprise",
         moduleTitle: "Module 6 : Connaître les principales aides à la création d'entreprise",
         content: `
-        <h1>📚 Introduction aux aides à la création d'entreprise</h1>
-        
         <p>Cette leçon fait partie du Module 6 : Connaître les principales aides à la création d'entreprise. Vous allez découvrir les différents types d'aides disponibles pour vous accompagner dans votre projet entrepreneurial.</p>
         
         <div style="text-align: center; margin: 30px 0;">
@@ -118,7 +116,6 @@ window.module6Content = {
         title: "Identification des aides à la création nationales, régionales, territoriales",
         moduleTitle: "Module 6 : Connaître les principales aides à la création d'entreprise",
         content: `
-        <h1>📚 Identification des aides à la création nationales, régionales, territoriales</h1>
         
         <p>Cette leçon détaille les aides disponibles selon les différents niveaux territoriaux : national, régional et local. Chaque niveau propose des dispositifs spécifiques adaptés aux enjeux de son territoire.</p>
         
@@ -229,7 +226,6 @@ window.module6Content = {
         title: "Application des aides en fonction du statut personnel",
         moduleTitle: "Module 6 : Connaître les principales aides à la création d'entreprise",
         content: `
-        <h1>📚 Application des aides en fonction du statut personnel</h1>
         
         <p>Cette leçon détaille les aides spécifiques selon votre statut personnel : demandeur d'emploi, salarié, étudiant, retraité, etc. Chaque statut ouvre droit à des dispositifs particuliers.</p>
         
@@ -386,7 +382,6 @@ window.module6Content = {
         title: "Maximisation des avantages des principales aides",
         moduleTitle: "Module 6 : Connaître les principales aides à la création d'entreprise",
         content: `
-        <h1>📚 Maximisation des avantages des principales aides</h1>
         
         <p>Cette leçon vous apprend à optimiser l'utilisation des aides disponibles, à les combiner efficacement et à maximiser leurs bénéfices pour votre projet de création d'entreprise.</p>
         
@@ -601,7 +596,6 @@ window.module6Content = {
         moduleTitle: "Module 6 : Connaître les principales aides à la création d'entreprise",
         type: "pdf",
         content: `
-        <h1>📚 Fiches Complémentaires</h1>
         
         <p>Cette leçon complète le module 6 avec des ressources supplémentaires et des fiches pratiques pour approfondir vos connaissances sur les aides à la création d'entreprise.</p>
         

--- a/lesson-content-module7.js
+++ b/lesson-content-module7.js
@@ -4,8 +4,6 @@ window.module7Content = {
         title: "Centre de Formalités des Entreprises (CFE)",
         moduleTitle: "Module 7 : Où s'adresser pour déclarer son entreprise",
         content: `
-        <h1>📚 Centre de Formalités des Entreprises (CFE)</h1>
-        
         <p>Cette leçon fait partie du Module 7 : Où s'adresser pour déclarer son entreprise. Vous allez découvrir les différents organismes compétents pour les formalités de création d'entreprise.</p>
         
         <div style="text-align: center; margin: 30px 0;">
@@ -153,7 +151,6 @@ window.module7Content = {
         title: "Présentation du centre de formalités des entreprises",
         moduleTitle: "Module 7 : Où s'adresser pour déclarer son entreprise",
         content: `
-        <h1>📚 Présentation du centre de formalités des entreprises</h1>
         
         <p>Cette leçon détaille le fonctionnement et l'organisation des centres de formalités des entreprises (CFE) pour vous aider à comprendre leur rôle dans le processus de création d'entreprise.</p>
         
@@ -269,7 +266,6 @@ window.module7Content = {
         title: "Explication des modalités de fonctionnement administratif",
         moduleTitle: "Module 7 : Où s'adresser pour déclarer son entreprise",
         content: `
-        <h1>📚 Explication des modalités de fonctionnement administratif</h1>
         
         <p>Cette leçon détaille les procédures administratives internes des centres de formalités des entreprises et leur fonctionnement opérationnel.</p>
         
@@ -451,7 +447,6 @@ window.module7Content = {
         title: "Connaissances des conséquences administratives de l'immatriculation",
         moduleTitle: "Module 7 : Où s'adresser pour déclarer son entreprise",
         content: `
-        <h1>📚 Connaissances des conséquences administratives de l'immatriculation</h1>
         
         <p>Cette leçon explique les conséquences et obligations qui découlent de l'immatriculation de votre entreprise auprès des différents organismes.</p>
         

--- a/lesson-content-module8.js
+++ b/lesson-content-module8.js
@@ -4,8 +4,6 @@ window.module8Content = {
         title: "Moins de risques que la création",
         moduleTitle: "Module 8 : Atouts de la reprise d'entreprise",
         content: `
-        <h1>📚 Moins de risques que la création</h1>
-        
         <p>Cette leçon fait partie du Module 8 : Atouts de la reprise d'entreprise. Vous allez découvrir pourquoi la reprise d'entreprise présente généralement moins de risques que la création pure.</p>
         
         <div style="text-align: center; margin: 30px 0;">
@@ -149,7 +147,6 @@ window.module8Content = {
         title: "Spécificités de la reprise d'entreprise",
         moduleTitle: "Module 8 : Atouts de la reprise d'entreprise",
         content: `
-        <h1>📚 Spécificités de la reprise d'entreprise</h1>
         
         <p><strong>🕵️‍♂️ Avez-vous déjà pensé à reprendre une entreprise et non à en créer une de toutes pièces ?</strong></p>
         
@@ -215,7 +212,6 @@ window.module8Content = {
         title: "Outils disponibles pour trouver une entreprise à reprendre",
         moduleTitle: "Module 8 : Atouts de la reprise d'entreprise",
         content: `
-        <h1>📚 Outils disponibles pour trouver une entreprise à reprendre</h1>
         
         <p><strong>🧐 Connaissiez-vous ces outils pour trouver une entreprise à reprendre ?</strong></p>
         
@@ -294,7 +290,6 @@ window.module8Content = {
         title: "Évaluation des avantages de la reprise par rapport à la création",
         moduleTitle: "Module 8 : Atouts de la reprise d'entreprise",
         content: `
-        <h1>📚 Évaluation des avantages de la reprise par rapport à la création</h1>
         
         <p><strong>Pourquoi créer une entreprise quand on peut en reprendre une existante ?</strong></p>
         

--- a/lesson-content-module9.js
+++ b/lesson-content-module9.js
@@ -4,8 +4,6 @@ window.module9Content = {
         title: "Comprendre les statuts juridiques",
         moduleTitle: "Module 9 : Obtenir les premières informations sur les structures juridiques",
         content: `
-        <h1>📚 Comprendre les statuts juridiques</h1>
-        
         <p>Cette leçon fait partie du Module 9 : Obtenir les premières informations sur les structures juridiques. Vous allez découvrir les différents statuts juridiques disponibles pour créer votre entreprise et leurs spécificités.</p>
         
         <div style="text-align: center; margin: 30px 0;">
@@ -92,7 +90,6 @@ window.module9Content = {
         title: "Compréhension des mécanismes financiers de base",
         moduleTitle: "Module 9 : Obtenir les premières informations sur les structures juridiques",
         content: `
-        <h1>📚 Compréhension des mécanismes financiers de base</h1>
         
         <p>Cette leçon fait partie du Module 9 : Obtenir les premières informations sur les structures juridiques. Vous allez découvrir les mécanismes financiers fondamentaux nécessaires à la gestion de votre entreprise.</p>
         
@@ -149,7 +146,6 @@ window.module9Content = {
         title: "Mise en place d'une organisation administrative et comptable efficace",
         moduleTitle: "Module 9 : Obtenir les premières informations sur les structures juridiques",
         content: `
-        <h1>📚 Mise en place d'une organisation administrative et comptable efficace</h1>
         
         <p>Cette leçon fait partie du Module 9 : Obtenir les premières informations sur les structures juridiques. Vous allez découvrir comment organiser efficacement l'administration et la comptabilité de votre entreprise.</p>
         
@@ -226,7 +222,6 @@ window.module9Content = {
         title: "Connaissance du calendrier des déclarations et des télédéclarations",
         moduleTitle: "Module 9 : Obtenir les premières informations sur les structures juridiques",
         content: `
-        <h1>📚 Connaissance du calendrier des déclarations et des télédéclarations</h1>
         
         <p>Cette leçon fait partie du Module 9 : Obtenir les premières informations sur les structures juridiques. Vous allez découvrir l'importance du calendrier des déclarations et des télédéclarations pour votre entreprise.</p>
         


### PR DESCRIPTION
Remove duplicate `<h1>` titles from lesson content as the title is already displayed via the `title` property.

The original setup displayed the lesson title twice: once from the `title` property at the top of the page, and again as an `<h1>` tag within the `content` property. This PR eliminates the redundant `<h1>` tags to ensure each lesson title appears only once, maintaining the desired H1 visual hierarchy through the `title` property's styling.

---
<a href="https://cursor.com/background-agent?bcId=bc-8986dcef-bc85-4c08-bd26-8b879d941162"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8986dcef-bc85-4c08-bd26-8b879d941162"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

