### PR TITLE
Fix pdf download paths in modules

### DIFF
--- a/lesson-content-module2.js
+++ b/lesson-content-module2.js
@@ -492,7 +492,7 @@ Identifier des indicateurs de performance clés pour suivre la croissance des ve
                     <div class="pdf-info">
                         <h3 class="pdf-title">Customer Journey Mapping A2TA2L</h3>
                         <p class="pdf-description">Guide complet pour créer votre carte de parcours client</p>
-                        <button class="download-button" onclick="downloadPDF('06_PDF_customerjourneymappingA2TA2L.pdf')">Télécharger</button>
+                        <button class="download-button" onclick="downloadPDF('02-05_customerjourneymappingA2TA2L.pdf')">Télécharger</button>
                     </div>
                 </div>
                 
@@ -501,7 +501,7 @@ Identifier des indicateurs de performance clés pour suivre la croissance des ve
                     <div class="pdf-info">
                         <h3 class="pdf-title">Les Étapes de la Création d'Entreprise - Le Marché</h3>
                         <p class="pdf-description">Guide détaillé sur l'analyse de marché pour les créateurs d'entreprise</p>
-                        <button class="download-button" onclick="downloadPDF('06_PDF_Lesetapesdelacreationdentreprise-Lemarche.pdf')">Télécharger</button>
+                        <button class="download-button" onclick="downloadPDF('02-06_Lesetapesdelacreationdentreprise-Lemarche.pdf')">Télécharger</button>
                     </div>
                 </div>
                 

--- a/lesson-content-module3.js
+++ b/lesson-content-module3.js
@@ -577,7 +577,7 @@ window.module3Content = {
                     <div class="pdf-info">
                         <h3 class="pdf-title">Plan Financier</h3>
                         <p class="pdf-description">Template pour créer votre plan financier détaillé</p>
-                        <button class="download-button" onclick="downloadPDF('06_PDF_PLANFINANCIER.pdf')">Télécharger</button>
+                        <button class="download-button" onclick="downloadPDF('03-06_planfinancierA2TA2L.pdf')">Télécharger</button>
                     </div>
                 </div>
                 
@@ -586,7 +586,7 @@ window.module3Content = {
                     <div class="pdf-info">
                         <h3 class="pdf-title">Lean Canvas</h3>
                         <p class="pdf-description">Modèle Lean Canvas pour structurer votre projet</p>
-                        <button class="download-button" onclick="downloadPDF('06_PDF_LEANCANVAS.pdf')">Télécharger</button>
+                        <button class="download-button" onclick="downloadPDF('03-06_leancanvasA2TA2L.pdf')">Télécharger</button>
                     </div>
                 </div>
                 
@@ -595,7 +595,7 @@ window.module3Content = {
                     <div class="pdf-info">
                         <h3 class="pdf-title">Value Proposition Canvas</h3>
                         <p class="pdf-description">Outil pour définir votre proposition de valeur</p>
-                        <button class="download-button" onclick="downloadPDF('02_PDF_ValuePropositionCanvasA2TA2L.pdf')">Télécharger</button>
+                        <button class="download-button" onclick="downloadPDF('10-05_ValuePropositionCanvasA2TA2L.pdf')">Télécharger</button>
                     </div>
                 </div>
                 
@@ -604,7 +604,7 @@ window.module3Content = {
                     <div class="pdf-info">
                         <h3 class="pdf-title">Business Plan - Les étapes essentielles</h3>
                         <p class="pdf-description">Guide pour rédiger un business plan efficace</p>
-                        <button class="download-button" onclick="downloadPDF('07_PDF_Lesetapesessentiellespourredigerunbusinessplan.pdf')">Télécharger</button>
+                        <button class="download-button" onclick="downloadPDF('03-07_Lesetapesessentiellespourredigerunbusinessplan.pdf')">Télécharger</button>
                     </div>
                 </div>
                 
@@ -613,7 +613,7 @@ window.module3Content = {
                     <div class="pdf-info">
                         <h3 class="pdf-title">Les étapes de la création d'entreprise - L'idée</h3>
                         <p class="pdf-description">Guide pour développer et valider votre idée d'entreprise</p>
-                        <button class="download-button" onclick="downloadPDF('07_PDF_Lesetapesdelacreationdentreprise-Lidee.pdf')">Télécharger</button>
+                        <button class="download-button" onclick="downloadPDF('03-07_Lesetapesdelacreationdentreprise-Lidee.pdf')">Télécharger</button>
                     </div>
                 </div>
                 
@@ -622,7 +622,7 @@ window.module3Content = {
                     <div class="pdf-info">
                         <h3 class="pdf-title">Les étapes de la création d'entreprise - Chiffres et Financements</h3>
                         <p class="pdf-description">Guide complet sur les aspects financiers</p>
-                        <button class="download-button" onclick="downloadPDF('07_PDF_Lesetapesdelacreationdentreprise-ChiffresetFinancements.pdf')">Télécharger</button>
+                        <button class="download-button" onclick="downloadPDF('03-07_Lesetapesdelacreationdentreprise-ChiffresetFinancements.pdf')">Télécharger</button>
                     </div>
                 </div>
                 
@@ -631,7 +631,7 @@ window.module3Content = {
                     <div class="pdf-info">
                         <h3 class="pdf-title">La création d'entreprise en 6 étapes</h3>
                         <p class="pdf-description">Méthodologie complète en 6 étapes</p>
-                        <button class="download-button" onclick="downloadPDF('07_PDF_Lacreationdentrepriseen6etapes.pdf')">Télécharger</button>
+                        <button class="download-button" onclick="downloadPDF('03-07_Lacreationdentrepriseen6etapes.pdf')">Télécharger</button>
                     </div>
                 </div>
             </div>

--- a/lesson-content-module4.js
+++ b/lesson-content-module4.js
@@ -413,7 +413,7 @@ window.module4Content = {
                     <div class="pdf-info">
                         <h3 class="pdf-title">Les étapes de la création d'entreprise - Structure et Création</h3>
                         <p class="pdf-description">Guide complet sur les structures juridiques et leur création</p>
-                        <button class="download-button" onclick="downloadPDF('05_PDF_Lesetapesdelacreationdentreprise-StructureetCreation.pdf')">Télécharger</button>
+                        <button class="download-button" onclick="downloadPDF('04-05_Lesetapesdelacreationdentreprise-StructureetCreation.pdf')">Télécharger</button>
                     </div>
                 </div>
                 

--- a/lesson.html
+++ b/lesson.html
@@ -317,7 +317,7 @@
         function downloadPDF(filename) {
             // Créer le téléchargement de PDF
             const link = document.createElement('a');
-            link.href = `assets/pdf/${filename}`;
+            link.href = `assets/pdfs/${filename}`;
             link.download = filename;
             link.target = '_blank';
             document.body.appendChild(link);


### PR DESCRIPTION
Correct PDF download paths from `assets/pdf` to `assets/pdfs` and update PDF filenames in modules 2, 3, and 4 to enable proper downloads.

---
<a href="https://cursor.com/background-agent?bcId=bc-d95d3083-8548-4114-a9ee-e6428e7a641b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d95d3083-8548-4114-a9ee-e6428e7a641b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

